### PR TITLE
fix: left-pad short P-256 coordinates in from_tomcrypt

### DIFF
--- a/utils/tsproto-types/src/crypto.rs
+++ b/utils/tsproto-types/src/crypto.rs
@@ -177,24 +177,27 @@ impl EccKeyPubP256 {
 				if let (Some(ASN1Block::Integer(_, x)), Some(ASN1Block::Integer(_, y))) =
 					(blocks.get(2), blocks.get(3))
 				{
-					let x_bytes = x.to_bytes_be().1;
-					let y_bytes = y.to_bytes_be().1;
 					let field_size = elliptic_curve::FieldBytesSize::<p256::NistP256>::to_usize();
-					if x_bytes.len() != field_size {
-						return Err(Error::WrongPublicKeyLength {
-							expected: field_size,
-							got: x_bytes.len(),
-						});
-					}
-					if y_bytes.len() != field_size {
-						return Err(Error::WrongPublicKeyLength {
-							expected: field_size,
-							got: y_bytes.len(),
-						});
-					}
+					let pad = |src: &BigInt| -> Result<elliptic_curve::FieldBytes<p256::NistP256>> {
+						let (sign, bytes) = src.to_bytes_be();
+						if sign == num_bigint::Sign::Minus {
+							return Err(Error::ParsePublicKeyFailed);
+						}
+						if bytes.len() > field_size {
+							return Err(Error::WrongPublicKeyLength {
+								expected: field_size,
+								got: bytes.len(),
+							});
+						}
+						let mut buf = elliptic_curve::FieldBytes::<p256::NistP256>::default();
+						buf[field_size - bytes.len()..].copy_from_slice(&bytes);
+						Ok(buf)
+					};
+					let x_padded = pad(x)?;
+					let y_padded = pad(y)?;
 					let enc_point = p256::EncodedPoint::from_affine_coordinates(
-						GenericArray::from_slice(x_bytes.as_slice()),
-						GenericArray::from_slice(y_bytes.as_slice()),
+						&x_padded,
+						&y_padded,
 						false,
 					);
 					let enc_point = p256::PublicKey::from_encoded_point(&enc_point);

--- a/utils/tsproto-types/src/crypto.rs
+++ b/utils/tsproto-types/src/crypto.rs
@@ -178,9 +178,9 @@ impl EccKeyPubP256 {
 					(blocks.get(2), blocks.get(3))
 				{
 					let field_size = elliptic_curve::FieldBytesSize::<p256::NistP256>::to_usize();
-					let pad = |src: &BigInt| -> Result<elliptic_curve::FieldBytes<p256::NistP256>> {
-						let (sign, bytes) = src.to_bytes_be();
-						if sign == num_bigint::Sign::Minus {
+					let to_coord = |src: &BigInt| -> Result<elliptic_curve::FieldBytes<p256::NistP256>> {
+						let (sign, mut bytes) = src.to_bytes_le();
+						if sign == Sign::Minus {
 							return Err(Error::ParsePublicKeyFailed);
 						}
 						if bytes.len() > field_size {
@@ -189,15 +189,17 @@ impl EccKeyPubP256 {
 								got: bytes.len(),
 							});
 						}
-						let mut buf = elliptic_curve::FieldBytes::<p256::NistP256>::default();
-						buf[field_size - bytes.len()..].copy_from_slice(&bytes);
-						Ok(buf)
+						// Pad if most significant bytes are zero
+						bytes.resize(field_size, 0);
+						// Convert to big-endian
+						bytes.reverse();
+						Ok(*GenericArray::from_slice(&bytes))
 					};
-					let x_padded = pad(x)?;
-					let y_padded = pad(y)?;
+					let x_coord = to_coord(x)?;
+					let y_coord = to_coord(y)?;
 					let enc_point = p256::EncodedPoint::from_affine_coordinates(
-						&x_padded,
-						&y_padded,
+						&x_coord,
+						&y_coord,
 						false,
 					);
 					let enc_point = p256::PublicKey::from_encoded_point(&enc_point);


### PR DESCRIPTION
## Problem

`EccKeyPubP256::from_tomcrypt` rejects P-256 coordinates that are shorter than 32 bytes. This sounds correct at first — P-256 coordinates are always 32 bytes — but there's a catch: `BigInt::to_bytes_be()` strips leading zeros. So when a coordinate happens to start with `0x00` (about a 1 in 256 chance per coordinate), it comes back as 31 bytes and gets rejected.

This means connecting to a TS3 server randomly fails depending on the server's ephemeral key. You might connect fine 5 times in a row, then fail on the 6th.

## Fix

Instead of rejecting short coordinates, left-pad them with zeros to 32 bytes. Invalid points are still caught by `p256::PublicKey::from_encoded_point` further down, so we don't lose any validation.

## How to reproduce

Connect to any TS3 server in a loop. Without the patch you'll eventually see:

FAILED: InvalidOmegaKey
  cause: Wrong public key length (expected 32, got 31)

```
Error.connection(field0: disconnected before ready: Failed to connect to server at "*****:9987": [Connect(InvalidOmegaKey(WrongPublicKeyLength { expected: 32, got: 31 }))])
```

## Safety

- Coordinates that are already 32 bytes are untouched (no padding needed).
- Coordinates that are somehow *longer* than 32 bytes aren't padded either — `from_encoded_point` will reject them.
- The `WrongPublicKeyLength` error variant stays in the enum for compatibility, it's just not triggered here anymore.